### PR TITLE
feat: 구글 로그인 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,7 @@ out/
 
 ### DB Config ###
 /src/main/resources/serviceAccountKey.json
+
+
+### Google config ###
+/src/main/resources/application-oauth.properties

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,17 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	implementation 'com.google.firebase:firebase-admin:8.0.1'
+
+
+	// 스프링 시큐리티
+	implementation('org.springframework.boot:spring-boot-starter-security')
+	implementation ('org.springframework.boot:spring-boot-starter-oauth2-client')
+
+
+
+	// lombok
+	implementation('org.projectlombok:lombok')
+	annotationProcessor('org.projectlombok:lombok')
 }
 
 test {

--- a/src/main/java/newspeed/config/auth/CustomOAuth2UserService.java
+++ b/src/main/java/newspeed/config/auth/CustomOAuth2UserService.java
@@ -1,0 +1,77 @@
+package newspeed.config.auth;
+
+
+import com.google.api.core.ApiFuture;
+import com.google.cloud.firestore.DocumentReference;
+import com.google.cloud.firestore.Firestore;
+import com.google.cloud.firestore.WriteResult;
+import com.google.firebase.cloud.FirestoreClient;
+import lombok.RequiredArgsConstructor;
+import newspeed.config.auth.dto.OAuthAttributes;
+import newspeed.config.auth.dto.SessionUser;
+import newspeed.domain.user.User;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import javax.servlet.http.HttpSession;
+import java.util.Collections;
+
+@RequiredArgsConstructor
+@Service
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+    private final HttpSession httpSession;
+
+    @Override
+    public OAuth2User loadUser (OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2UserService<OAuth2UserRequest, OAuth2User>
+                delegate = new DefaultOAuth2UserService();
+        // userRequest 로 전달받은 유저 정보를 OAuth2User 객체로 받는다
+        OAuth2User oAuth2User = delegate.loadUser(userRequest);
+
+        // 현재 로그인 진행 중인 서비스를 구분하는 코드
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+
+        // OAuth2 로그인 진행 시 키가 되는 필드값
+        String userNameAttributeName = userRequest.getClientRegistration()
+                .getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName();
+
+        // OAuth2UserService 를 통해 가져온 OAuth2User 의 attribute 를 담은 클래스
+        OAuthAttributes attributes = OAuthAttributes.of(registrationId, userNameAttributeName,
+                oAuth2User.getAttributes());
+
+        User user = attributes.toEntity();
+        System.out.println(user.getEmail());
+
+
+        // Cloud Firestore
+
+        Firestore db = FirestoreClient.getFirestore();
+
+
+
+        // google Login 을 통해서 받아온 유저 정보를 firestore 에 저장
+        DocumentReference addedDocRef = db.collection("googleUser").document();
+        System.out.println("Added document with ID: " + addedDocRef.getId());
+
+        ApiFuture<WriteResult> writeResult = addedDocRef.set(user);
+
+
+
+        // 구글 로그인을 통해서 전달받은 유저의 정보를 session 객체에 공유 설정
+        httpSession.setAttribute("user", new SessionUser(user));
+
+        return new DefaultOAuth2User(Collections.singleton(new
+                SimpleGrantedAuthority(user.getRoleKey())),
+                attributes.getAttributes(),
+                attributes.getNameAttributeKey());
+    }
+
+
+}

--- a/src/main/java/newspeed/config/auth/SecurityConfig.java
+++ b/src/main/java/newspeed/config/auth/SecurityConfig.java
@@ -1,0 +1,32 @@
+package newspeed.config.auth;
+
+
+import lombok.RequiredArgsConstructor;
+import newspeed.domain.user.Role;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+
+@RequiredArgsConstructor
+@EnableWebSecurity
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+    private final CustomOAuth2UserService customOAuth2UserService;
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        // h2-console 화면을 사용하기 위한 코드
+        http.csrf().disable().headers().frameOptions().disable()
+                // URL 별 권한 관리를 설정하는 옵션의 시작점
+                .and().authorizeRequests()
+                // 권한과 관계없이 모든 것을 허용하는 URL
+                .antMatchers("/","/css/**","/images/**","/js/**").permitAll()
+                // /api/v1 에 해당하는 기능은 user 의 경우만 접근할 수 있도록 하는 코드
+                .antMatchers("/api/v1/**").hasRole(Role.USER.name())
+                // 설정되지 않은 URL 의 경우 인증된 사용자들에게만 허용
+                .anyRequest().authenticated()
+                // 로그아웃 설정의 진입점 , 로그아웃이 성공할 경우 메인페이지로 이동
+                .and().logout().logoutSuccessUrl("/")
+                // 로그인 성공 후 사용자 정보를 가져올 때 설정
+               .and().oauth2Login().userInfoEndpoint().userService(customOAuth2UserService);
+    }
+}

--- a/src/main/java/newspeed/config/auth/dto/OAuthAttributes.java
+++ b/src/main/java/newspeed/config/auth/dto/OAuthAttributes.java
@@ -1,0 +1,53 @@
+package newspeed.config.auth.dto;
+
+
+import lombok.Builder;
+import lombok.Getter;
+import newspeed.domain.user.Role;
+import newspeed.domain.user.User;
+
+import java.util.Map;
+
+@Getter
+public class OAuthAttributes {
+
+    private Map<String, Object> attributes;
+    private String nameAttributeKey;
+    private String name;
+    private String email;
+    private String picture;
+
+    @Builder
+    public OAuthAttributes(Map<String, Object> attributes,
+                           String nameAttributeKey,
+                           String name,
+                           String email,
+                           String picture) {
+        this.attributes = attributes;
+        this.nameAttributeKey = nameAttributeKey;
+        this.name = name;
+        this.email = email;
+        this.picture = picture;
+    }
+    // OAuth2User 에서 반환하는 사용자 정보는 Map 자료구조이기 떄문에 값 하나하나를 변환해야 한다
+    public static OAuthAttributes of(String registrationId,
+                                     String userNameAttributeName,
+                                     Map<String, Object> attributes) {
+        return OAuthAttributes.builder()
+                .name((String) attributes.get("name"))
+                .email((String) attributes.get("email"))
+                .picture((String) attributes.get("picture"))
+                .attributes(attributes)
+                .nameAttributeKey(userNameAttributeName)
+                .build();
+    }
+    // User 개체를 생성 , 생성하는 시점은 처음 가입할 때
+    public User toEntity() {
+        return User.builder()
+                .name(name)
+                .email(email)
+                .picture(picture)
+                .role(Role.GUEST)
+                .build();
+    }
+}

--- a/src/main/java/newspeed/config/auth/dto/SessionUser.java
+++ b/src/main/java/newspeed/config/auth/dto/SessionUser.java
@@ -1,0 +1,20 @@
+package newspeed.config.auth.dto;
+
+
+import lombok.Getter;
+import newspeed.domain.user.User;
+
+import java.io.Serializable;
+
+@Getter
+public class SessionUser implements Serializable {
+    private String name;
+    private String email;
+    private String picture;
+
+    public SessionUser(User user) {
+        this.name = user.getName();
+        this.email = user.getEmail();
+        this.picture = user.getPicture();
+    }
+}

--- a/src/main/java/newspeed/domain/user/Role.java
+++ b/src/main/java/newspeed/domain/user/Role.java
@@ -1,0 +1,17 @@
+package newspeed.domain.user;
+
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Role {
+
+    GUEST("ROLE_GUEST", "손님"),
+    USER("ROLE_USER", "일반 사용자");
+
+    private final String key;
+    private final String title;
+
+}

--- a/src/main/java/newspeed/domain/user/User.java
+++ b/src/main/java/newspeed/domain/user/User.java
@@ -1,0 +1,33 @@
+package newspeed.domain.user;
+
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class User {
+
+    private Long id;
+    private String name;
+    private String email;
+    private String picture;
+    private Role role;
+
+    @Builder
+    public User(String name, String email, String picture, Role role) {
+        this.name = name;
+        this.email = email;
+        this.picture = picture;
+        this.role = role;
+    }
+
+    public User update(String name, String picture) {
+        this.name = name;
+        this.picture = picture;
+        return this;
+    }
+
+    public String getRoleKey() {
+        return this.role.getKey();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,4 @@
+spring.profiles.include=oauth
+server.port = 8081
 
+spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration


### PR DESCRIPTION
- oauth2 를 통해 구글 로그인 기능 추가
- 전달받은 정보 firestore에 저장

보완해야할 부분:
가입된 아이디인지 확인하고 가입된 아이디일 시 db에 추가로 저장되지 않도록 수정 필요